### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "cpp"
+run = ""

--- a/README.md
+++ b/README.md
@@ -11,3 +11,4 @@ GitHub: https://github.com/MartianSpaceFox/COP_Final_HealthCareSys
 
 Comments:
 
+[![Run on Repl.it](https://repl.it/badge/github/MartianSpaceFox/COP_Final_HealthCareSys)](https://repl.it/github/MartianSpaceFox/COP_Final_HealthCareSys)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).